### PR TITLE
修复select检测多维数组

### DIFF
--- a/src/Lego/Field/Provider/Select.php
+++ b/src/Lego/Field/Provider/Select.php
@@ -7,24 +7,6 @@ class Select extends Text
 {
     use FilterWhereEquals;
 
-    function deep_in_array($value, $array) {
-        foreach($array as $item) {
-            if(!is_array($item)) {
-                if ($item == $value) {
-                    return true;
-                } else {
-                    continue;
-                }
-            }
-            if(in_array($value, $item)) {
-                return true;
-            } else if(self::deep_in_array($value, $item)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     protected function initialize()
     {
         parent::initialize();
@@ -35,10 +17,28 @@ class Select extends Text
                 return array_key_exists($value, $this->getOptions()) ? null : '非法选项';
             } else {
                 // 多维数组
-                return self::deep_in_array($value, $this->getOptions()) ? null : '非法选项';
+                return $this->deep_in_array($value, $this->getOptions()) ? null : '非法选项';
             }
 
         });
+    }
+
+    protected function deep_in_array($value, array $array) {
+        foreach($array as $item) {
+            if(!is_array($item)) {
+                if ($item == $value) {
+                    return true;
+                } else {
+                    continue;
+                }
+            }
+            if(in_array($value, $item)) {
+                return true;
+            } else if($this->deep_in_array($value, $item)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public function getDisplayValue()

--- a/src/Lego/Field/Provider/Select.php
+++ b/src/Lego/Field/Provider/Select.php
@@ -12,33 +12,20 @@ class Select extends Text
         parent::initialize();
 
         $this->validator(function ($value) {
-            if (count($this->getOptions())==count($this->getOptions(), COUNT_RECURSIVE)) {
-                // 一维数组
-                return array_key_exists($value, $this->getOptions()) ? null : '非法选项';
-            } else {
-                // 多维数组
-                return $this->deepInArray($value, $this->getOptions()) ? null : '非法选项';
-            }
-
+            return $this->deepInArray($value, $this->getOptions()) ? null : '非法选项';
         });
     }
 
     protected function deepInArray($value, array $array) {
-        foreach($array as $item) {
-            if(!is_array($item)) {
-                if ($item == $value) {
-                    return true;
-                } else {
-                    continue;
-                }
-            }
-            if(in_array($value, $item)) {
+        foreach($array as $key => $item) {
+            if (is_array($item) && $this->deepInArray($value, $item)) {
                 return true;
-            } else if($this->deepInArray($value, $item)) {
+            } elseif ($value === $key) {
                 return true;
+            } else {
+                return false;
             }
         }
-        return false;
     }
 
     public function getDisplayValue()

--- a/src/Lego/Field/Provider/Select.php
+++ b/src/Lego/Field/Provider/Select.php
@@ -20,14 +20,13 @@ class Select extends Text
         foreach($array as $key => $item) {
             if (is_array($item) && $this->deepInArray($value, $item)) {
                 return true;
-            } elseif ($value === $key) {
+            } elseif ($value == $key) {
                 return true;
-            } else {
-                return false;
             }
         }
+        return false;
     }
-
+    
     public function getDisplayValue()
     {
         $key = $this->takeDefaultInputValue();

--- a/src/Lego/Field/Provider/Select.php
+++ b/src/Lego/Field/Provider/Select.php
@@ -17,13 +17,13 @@ class Select extends Text
                 return array_key_exists($value, $this->getOptions()) ? null : '非法选项';
             } else {
                 // 多维数组
-                return $this->deep_in_array($value, $this->getOptions()) ? null : '非法选项';
+                return $this->deepInArray($value, $this->getOptions()) ? null : '非法选项';
             }
 
         });
     }
 
-    protected function deep_in_array($value, array $array) {
+    protected function deepInArray($value, array $array) {
         foreach($array as $item) {
             if(!is_array($item)) {
                 if ($item == $value) {
@@ -34,7 +34,7 @@ class Select extends Text
             }
             if(in_array($value, $item)) {
                 return true;
-            } else if($this->deep_in_array($value, $item)) {
+            } else if($this->deepInArray($value, $item)) {
                 return true;
             }
         }

--- a/src/Lego/Field/Provider/Select.php
+++ b/src/Lego/Field/Provider/Select.php
@@ -7,12 +7,37 @@ class Select extends Text
 {
     use FilterWhereEquals;
 
+    function deep_in_array($value, $array) {
+        foreach($array as $item) {
+            if(!is_array($item)) {
+                if ($item == $value) {
+                    return true;
+                } else {
+                    continue;
+                }
+            }
+            if(in_array($value, $item)) {
+                return true;
+            } else if(self::deep_in_array($value, $item)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     protected function initialize()
     {
         parent::initialize();
 
         $this->validator(function ($value) {
-            return array_key_exists($value, $this->getOptions()) ? null : '非法选项';
+            if (count($this->getOptions())==count($this->getOptions(), COUNT_RECURSIVE)) {
+                // 一维数组
+                return array_key_exists($value, $this->getOptions()) ? null : '非法选项';
+            } else {
+                // 多维数组
+                return self::deep_in_array($value, $this->getOptions()) ? null : '非法选项';
+            }
+
         });
     }
 


### PR DESCRIPTION
### 修复Lego自带的select检测多维数组
- 一维数组检测：依旧检测key
- 多维数组检测：检测value是否存在