### PR TITLE
fix关联关系连接符

### DIFF
--- a/src/Lego/Field/Concerns/HtmlOperator.php
+++ b/src/Lego/Field/Concerns/HtmlOperator.php
@@ -28,7 +28,7 @@ trait HtmlOperator
 
     protected function initializeHtmlOperator()
     {
-        $this->elementName = str_replace(['.', ':'], '-', $this->name());
+        $this->elementName = str_replace(['.', ':'], '_', $this->name());
     }
 
     public function elementId()


### PR DESCRIPTION
```php
$filter->addText('room.search_text', '公寓编号|地址|小区');

搜索时会变成 room-search_text, 原来用rapyd时 room_search_text
```
在公寓详情页去查找合同现在 搜不到

卫爷你评估一下 是改这里 还是修改 laputa代码