### PR TITLE
fix 判断批处理模式逻辑错误

### DIFF
--- a/src/Lego/Widget/Grid/Concerns/HasBatch.php
+++ b/src/Lego/Widget/Grid/Concerns/HasBatch.php
@@ -58,7 +58,7 @@ trait HasBatch
 
     public function enableBatchMode()
     {
-        if (!$this->batches()) {
+        if (count($this->batches())) {
             return;
         }
 
@@ -72,6 +72,6 @@ trait HasBatch
 
     public function batchModeEnabled()
     {
-        return Session::get($this->batchModeSessionKey, false);
+        return count($this->batches()) && Session::get($this->batchModeSessionKey, false);
     }
 }

--- a/src/Lego/Widget/Grid/Grid.php
+++ b/src/Lego/Widget/Grid/Grid.php
@@ -166,7 +166,7 @@ class Grid extends Widget
             $this->addButton(self::BTN_RIGHT_TOP, $name, $url, 'lego-export-' . $name);
         }
 
-        if ($this->batches()) {
+        if (count($this->batches())) {
             LegoAssets::js('components/vue/dist/vue.min.js');
             LegoAssets::js('js/batch.js');
         }


### PR DESCRIPTION
现象：

当在其他页面进入批处理模式后，再进入没有批处理的页面时，仍然会出现批处理的按钮