### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=7.0.0",
-        "laravel/framework": "~5.2",
+        "laravel/framework": "5.2.* || 5.3.* || 5.4.* || 5.5.*",
         "laravelcollective/html": "~5.2",
         "mobiledetect/mobiledetectlib": "^2.8",
         "maatwebsite/excel": "~2.1.0",


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.